### PR TITLE
Apply dark grey theme

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -10,4 +10,5 @@
   flex: 1;
   padding: 20px;
   overflow-y: auto;
+  border-radius: 10px;
 }

--- a/src/styles/Configuration.css
+++ b/src/styles/Configuration.css
@@ -1,8 +1,9 @@
 @import './variables.css';
 
 .configuration {
-  background-color: var(--text-color);
-  border-top: 1px solid var(--primary-color);
+  background-color: var(--secondary-color);
+  border-top: 1px solid var(--accent-color);
   padding: 20px;
   margin-top: auto;
+  border-radius: 10px;
 }

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -4,7 +4,7 @@
   max-width: 320px;
   margin: 60px auto;
   padding: 20px;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--text-color);
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
@@ -24,7 +24,7 @@
   padding: 8px;
   box-sizing: border-box;
   border: 1px solid var(--secondary-color);
-  border-radius: 4px;
+  border-radius: 6px;
 }
 
 .login-container .error {
@@ -37,7 +37,7 @@
   color: var(--text-color);
   border: none;
   padding: 8px 12px;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
 }
 

--- a/src/styles/Sidebar.css
+++ b/src/styles/Sidebar.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   padding-top: 20px;
+  border-radius: 10px;
 }
 
 .sidebar ul {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,5 +4,5 @@ body {
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;
   background-color: var(--bg-color);
-  color: var(--primary-color);
+  color: var(--text-color);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,7 +1,8 @@
 :root {
-  --primary-color: #37474f;
-  --secondary-color: #00838f;
-  --accent-color: #4caf50;
-  --bg-color: #eceff1;
+  /* Dark palette based on blacks and greys */
+  --primary-color: #1a1a1a;
+  --secondary-color: #333333;
+  --accent-color: #4d4d4d;
+  --bg-color: #000000;
   --text-color: #ffffff;
 }


### PR DESCRIPTION
## Summary
- switch to black and grey color palette
- add rounded corners to main sections
- keep icons in sidebar

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e667fca00833384e51ad24a52118a